### PR TITLE
Fix typo in language model

### DIFF
--- a/lib/models/languages/language.models.ts
+++ b/lib/models/languages/language.models.ts
@@ -48,7 +48,7 @@ export namespace LanguageModels {
 
     export interface IAddLanguageData {
         name: string;
-        codname: string;
+        codename: string;
         is_active?: boolean;
         fallback_language?: SharedModels.IReferenceObject;
         external_id?: string;

--- a/test-browser/languages/add-language.spec.ts
+++ b/test-browser/languages/add-language.spec.ts
@@ -9,7 +9,7 @@ describe('Add language', () => {
         getTestClientWithJson(responseJson)
             .addLanguage()
             .withData({
-                codname: 'x',
+                codename: 'x',
                 external_id: undefined,
                 fallback_language: undefined,
                 is_active: true,


### PR DESCRIPTION
### Motivation

There was a typo in the language model that could create a 500 server error when it was used.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

