### PR TITLE
Added is_required to ILinkedItemsInType

### DIFF
--- a/lib/models/content-types/content-type-elements.builder.ts
+++ b/lib/models/content-types/content-type-elements.builder.ts
@@ -76,6 +76,7 @@ export namespace ElementsInContentType {
         name: string;
         guidelines?: string;
         type: 'modular_content';
+        is_required?: boolean;
         codename?: string;
         external_id?: string;
         content_group?: SharedContracts.IReferenceObjectContract;


### PR DESCRIPTION
`ILinkedItemsInType` was missing `is_required`. Adding this allows the `is_required` to be configured.

### Motivation

Adds the ability to set the `is_required` on linked items.
