### PR TITLE
Added codename to IMultipleChoiceInType

### DIFF
--- a/lib/models/content-types/content-type-elements.builder.ts
+++ b/lib/models/content-types/content-type-elements.builder.ts
@@ -101,6 +101,7 @@ export namespace ElementsInContentType {
         external_id?: string;
         content_group?: SharedContracts.IReferenceObjectContract;
         guidelines?: string;
+        codename?: string;
     }
 
     export interface INumberInType extends IElementInContentType {


### PR DESCRIPTION
### Motivation

When creating migrations, I noticed that IMultipleChoiceInType does not allow for a codename to be set, while the Management API v2 does allow for this property.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [-] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?

Old version: codename is not accepted for MultipleChoiceType
New version: codename is accepted :)
