### PR TITLE
Correct the generic `get()` HTTP method

### DIFF
--- a/lib/queries/generic/get-query.class.ts
+++ b/lib/queries/generic/get-query.class.ts
@@ -15,7 +15,7 @@ export class GetQuery extends BaseQuery<GenericResponses.GenericResponse> {
     }
 
     toPromise(): Promise<GenericResponses.GenericResponse> {
-        return this.queryService.genericDeleteResponse(this.getUrl(), this.queryConfig);
+        return this.queryService.genericGetResponse(this.getUrl(), this.queryConfig);
     }
 
     protected getAction(): string {


### PR DESCRIPTION
### Motivation

Fix `client.get()` so that it uses `GET` as the HTTP method rather than `DELETE`.

This appears to have been a long-running bug, present since v0.3.20, ref: https://github.com/Kentico/kontent-management-sdk-js/commit/ce00b4946963855ae0016da2e9514bfb248ddfd7#diff-0978baf926ca38cfd7ea192305397df44ebdd634af9a51c98e199d34e0b1233dR18

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

```
await apiClient.get().withAction("projects/<your_project_id>").toPromise();
```

Currently errors with the following:

```
  Message: The requested resource with API version '2' does not support HTTP method 'DELETE'. No route providing a controller name with API version '2' was found to match HTTP method 'DELETE' and request URI 'https://draft-backend-euwest.azurewebsites.net/manageApi/v2/projects/REDACTED'. For more information about API versioning, see the API reference at https://docs.kontent.ai/reference.
  Code: 10
  Validation Errors: []
```