### PR TITLE
fix: Return `urlSlugElement()` to elements builder

### DIFF
--- a/lib/models/content-types/content-type-elements.builder.ts
+++ b/lib/models/content-types/content-type-elements.builder.ts
@@ -2,6 +2,10 @@ import { ContentTypeSnippetElements } from '../content-type-snippets/content-typ
 import { ContentTypeElements } from '../elements/content-type-element.models';
 
 export class ContentTypeElementsBuilder extends ContentTypeSnippetElements {
+    urlSlugElement(element: ContentTypeElements.IUrlSlugElementData): ContentTypeElements.IUrlSlugElementData {
+        return element;
+    }
+
     snippetElement(element: ContentTypeElements.ISnippetElementData): ContentTypeElements.ISnippetElementData {
         return element;
     }


### PR DESCRIPTION
### Motivation

Add the `urlSlugElement()` method back to the `ContentTypeElementsBuilder` so that we can get the `ContentTypeElements.IUrlSlugElementData` type safety, rather than having to rely on `any()`.

This bug appears to have been introduced in v1.7.0, during the refactor of `ContentTypeElementsBuilder` to extend from `ContentTypeSnippetElements`, ref: https://github.com/Kentico/kontent-management-sdk-js/commit/728a5e1b37b46314eba7ff04d73bdab53b05a8dc

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Try to use `urlSlugElement()` on an instance of `ContentTypeElementsBuilder`. Currently, this gives a type error:

```
Property 'urlSlugElement' does not exist on type 'ContentTypeElementsBuilder'.ts(2339)
```
