### PR TITLE
feat: adds is_non_localizable property to type elements

### DIFF
--- a/lib/models/elements/content-type-element.models.ts
+++ b/lib/models/elements/content-type-element.models.ts
@@ -55,6 +55,7 @@ export namespace ContentTypeElements {
             condition: 'at_most' | 'exactly' | 'at_least';
         };
         is_required?: boolean;
+        is_non_localizable?: boolean;
     }
 
     export interface ISnippetElementData extends IElementShared {
@@ -62,6 +63,7 @@ export namespace ContentTypeElements {
         type: 'snippet';
         codename: string;
         external_id?: string;
+        is_non_localizable?: boolean;
     }
 
     export interface ICustomElementData extends IElementShared {
@@ -73,6 +75,7 @@ export namespace ContentTypeElements {
         external_id?: string;
         guidelines?: string;
         is_required?: boolean;
+        is_non_localizable?: boolean;
         allowed_elements?: SharedContracts.IReferenceObjectContract[];
     }
 
@@ -80,6 +83,7 @@ export namespace ContentTypeElements {
         name: string;
         type: 'date_time';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         guidelines?: string;
         codename?: string;
         external_id?: string;
@@ -90,6 +94,7 @@ export namespace ContentTypeElements {
         type: 'guidelines';
         codename?: string;
         external_id?: string;
+        is_non_localizable?: boolean;
     }
 
     export interface ILinkedItemsElementData extends IElementShared {
@@ -102,6 +107,7 @@ export namespace ContentTypeElements {
         guidelines?: string;
         type: 'modular_content';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename?: string;
         external_id?: string;
     }
@@ -116,6 +122,7 @@ export namespace ContentTypeElements {
         guidelines?: string;
         type: 'subpages';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename?: string;
         external_id?: string;
     }
@@ -131,6 +138,7 @@ export namespace ContentTypeElements {
         name: string;
         type: 'multiple_choice';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         external_id?: string;
         guidelines?: string;
         codename?: string;
@@ -140,6 +148,7 @@ export namespace ContentTypeElements {
         name: string;
         type: 'number';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename?: string;
         external_id?: string;
         guidelines?: string;
@@ -164,6 +173,7 @@ export namespace ContentTypeElements {
         name: string;
         type: 'rich_text';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename?: string;
         external_id?: string;
         guidelines?: string;
@@ -180,6 +190,7 @@ export namespace ContentTypeElements {
         guidelines?: string;
         type: 'taxonomy';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename?: string;
         external_id?: string;
         term_count_limit?: {
@@ -192,6 +203,7 @@ export namespace ContentTypeElements {
         name: string;
         type: 'text';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename?: string;
         external_id?: string;
         guidelines?: string;
@@ -214,6 +226,7 @@ export namespace ContentTypeElements {
         name: string;
         type: 'url_slug';
         is_required?: boolean;
+        is_non_localizable?: boolean;
         codename: string;
         external_id?: string;
         guidelines?: string;

--- a/test/browser/content-types/add-content-type.spec.ts
+++ b/test/browser/content-types/add-content-type.spec.ts
@@ -21,7 +21,8 @@ describe('Add content type', () => {
                         }),
                         builder.textElement({
                             name: 'title',
-                            type: 'text'
+                            type: 'text',
+                            is_non_localizable: true,
                         }),
                         builder.taxonomyElement({
                             type: 'taxonomy',

--- a/test/browser/fake-responses/content-type-snippets/fake-add-content-type-snippet.json
+++ b/test/browser/fake-responses/content-type-snippets/fake-add-content-type-snippet.json
@@ -10,7 +10,8 @@
         "guidelines": "",
         "type": "text",
         "id": "116a2441-6441-7124-c85b-46a4fef5dcb9",
-        "codename": "video_id"
+        "codename": "video_id",
+        "is_non_localizable": true
       },
       {
         "mode": "single",
@@ -30,7 +31,8 @@
         "guidelines": "",
         "type": "multiple_choice",
         "id": "87924912-4861-aa84-176a-1eae7b22529b",
-        "codename": "video_host"
+        "codename": "video_host",
+        "is_non_localizable": false
       }
     ]
   }

--- a/test/browser/fake-responses/content-type-snippets/fake-list-content-type-snippets.json
+++ b/test/browser/fake-responses/content-type-snippets/fake-list-content-type-snippets.json
@@ -11,14 +11,16 @@
            "guidelines": "Length: 30–60 characters",
            "type": "text",
            "id": "09398b24-61ed-512e-5b5c-affd54a098e5",
-           "codename": "meta_title"
+           "codename": "meta_title",
+           "is_non_localizable": false
          },
         {
           "name": "Meta description",
           "guidelines": "Length: 70–150 characters",
           "type": "text",
           "id": "2e555cc1-1eae-520c-189e-28548904f529",
-          "codename": "meta_description"
+          "codename": "meta_description",
+          "is_non_localizable": false
         }
       ]
     }

--- a/test/browser/fake-responses/content-type-snippets/fake-modify-content-type-snippet.json
+++ b/test/browser/fake-responses/content-type-snippets/fake-modify-content-type-snippet.json
@@ -10,6 +10,7 @@
         "name": "My meta title",
         "guidelines": "Length: 30–60 characters.",
         "is_required": false,
+        "is_non_localizable": false,
         "type": "text",
         "external_id": "my-meta-title-id",
         "id": "0eb2bcda-5b9f-4425-b9e1-c7679356e456",
@@ -23,6 +24,7 @@
         "name": "My meta description",
         "guidelines": "Length: 70-150 characters.",
         "is_required": false,
+        "is_non_localizable": false,
         "type": "text",
         "id": "f79ad793-b01d-42b0-b06c-7043cd9b6f31",
         "codename": "my_metadata_snippet__my_meta_description"
@@ -44,6 +46,7 @@
         "name": "My multiple choice",
         "guidelines": null,
         "is_required": false,
+        "is_non_localizable": true,
         "id": "fcc30f1e-9abf-41da-8693-ed89f3be438d",
         "codename": "my_metadata_snippet__my_multiple_choice",
         "type": "multiple_choice",

--- a/test/browser/fake-responses/content-type-snippets/fake-view-content-type-snippet.json
+++ b/test/browser/fake-responses/content-type-snippets/fake-view-content-type-snippet.json
@@ -9,14 +9,16 @@
       "guidelines": "Length: 30–60 characters",
       "type": "text",
       "id": "09398b24-61ed-512e-5b5c-affd54a098e5",
-      "codename": "meta_title"
+      "codename": "meta_title",
+      "is_non_localizable": false
     },
     {
       "name": "Meta description",
       "guidelines": "Length: 70–150 characters",
       "type": "text",
       "id": "2e555cc1-1eae-520c-189e-28548904f529",
-      "codename": "meta_description"
+      "codename": "meta_description",
+      "is_non_localizable": false
     }
   ]
 }

--- a/test/browser/fake-responses/content-types/fake-add-content-type.json
+++ b/test/browser/fake-responses/content-types/fake-add-content-type.json
@@ -11,6 +11,7 @@
       "type": "text",
       "id": "116a2441-6441-7124-c85b-46a4fef5dcb9",
       "codename": "video_id",
+      "is_non_localizable": true,
       "validation_regex": {
         "regex": "^[a-z]$",
         "flags": null,
@@ -34,6 +35,7 @@
       "name": "Video host",
       "guidelines": "",
       "type": "multiple_choice",
+      "is_non_localizable": false,
       "id": "87924912-4861-aa84-176a-1eae7b22529b",
       "codename": "video_host"
     }

--- a/test/browser/fake-responses/content-types/fake-list-content-types.json
+++ b/test/browser/fake-responses/content-types/fake-list-content-types.json
@@ -11,7 +11,8 @@
             "guidelines": "",
             "type": "text",
             "id": "116a2441-6441-7124-c85b-46a4fef5dcb9",
-            "codename": "video_id"
+            "codename": "video_id",
+            "is_non_localizable": true
           }
         ]
       },
@@ -25,28 +26,32 @@
             "guidelines": "",
             "type": "guidelines",
             "id": "9367da14-3d08-4ed1-4841-24bf8055f916",
-            "codename": "n9367da14_3d08_4ed1_4841_24bf8055f916"
+            "codename": "n9367da14_3d08_4ed1_4841_24bf8055f916",
+            "is_non_localizable": false
           },
           {
             "name": "Hero unit",
             "guidelines": "Assign 1 Hero unit that has been prepared for a home page. ",
             "type": "modular_content",
             "id": "2b15a8f3-2e5f-7d01-4d8e-5b22e222aa76",
-            "codename": "hero_unit"
+            "codename": "hero_unit",
+            "is_non_localizable": false
           },
           {
             "name": "Articles",
             "guidelines": "Assign all articles which should be displayed on the home page.",
             "type": "modular_content",
             "id": "222f3a69-a54f-3e92-83ac-05f8a08e667f",
-            "codename": "articles"
+            "codename": "articles",
+            "is_non_localizable": false
           },
           {
             "name": "Our story",
             "guidelines": "Assign 1 Fact about us which will be displayed on the home page.",
             "type": "modular_content",
             "id": "617bccc0-4844-4beb-4ede-6247e954633a",
-            "codename": "our_story"
+            "codename": "our_story",
+            "is_non_localizable": false
           },
           {
             "snippet": {
@@ -54,7 +59,8 @@
             },
             "type": "snippet",
             "id": "255d6748-ba3a-1b59-af5c-afd4a7d6cb4f",
-            "codename": "metadata"
+            "codename": "metadata",
+            "is_non_localizable": false
           }
         ]
       }

--- a/test/browser/fake-responses/content-types/fake-modify-content-type.json
+++ b/test/browser/fake-responses/content-types/fake-modify-content-type.json
@@ -9,7 +9,8 @@
       "guidelines": "Here you can tell users how to fill in the element.",
       "type": "text",
       "id": "116a2441-6441-7124-c85b-46a4fef5dcb9",
-      "codename": "my_text_element"
+      "codename": "my_text_element",
+      "is_non_localizable": false
     },
     {
       "mode": "multiple",
@@ -30,7 +31,8 @@
       "type": "multiple_choice",
       "id": "87924912-4861-aa84-176a-1eae7b22529b",
       "codename": "my_multiple_choice_element",
-      "external_id": "my-multiple-choice-id"
+      "external_id": "my-multiple-choice-id",
+      "is_non_localizable": true
     },
     {
       "name": "My title",
@@ -38,7 +40,8 @@
       "type": "text",
       "external_id": "my-title-id",
       "id": "eacf283d-7e60-57b9-a68e-91180bfebb6d",
-      "codename": "my_title"
+      "codename": "my_title",
+      "is_non_localizable": false
     }
   ]
 }

--- a/test/browser/fake-responses/content-types/fake-view-content-type.json
+++ b/test/browser/fake-responses/content-types/fake-view-content-type.json
@@ -18,7 +18,8 @@
       "guidelines": "",
       "type": "text",
       "id": "116a2441-6441-7124-c85b-46a4fef5dcb9",
-      "codename": "video_id"
+      "codename": "video_id",
+      "is_non_localizable": true
     },
     {
       "mode": "single",
@@ -37,6 +38,7 @@
       "name": "Video host",
       "guidelines": "",
       "type": "multiple_choice",
+      "is_non_localizable": false,
       "id": "87924912-4861-aa84-176a-1eae7b22529b",
       "codename": "video_host"
     },
@@ -46,6 +48,7 @@
         "id": "41f013c2-d3a6-4fbf-af1f-466f6326e5c4"
       },
       "is_required": false,
+      "is_non_localizable": false,
       "term_count_limit": {
         "value": 5,
         "condition": "at_least"


### PR DESCRIPTION
### Motivation

- Add `is_non_localizable` property to content type/snippet elements.
- Fix tests related to content types/snippets.
- More information #64 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
