### PR TITLE
Feature/extend url slug with validation regex

### DIFF
--- a/lib/models/elements/content-type-element.models.ts
+++ b/lib/models/elements/content-type-element.models.ts
@@ -218,6 +218,12 @@ export namespace ContentTypeElements {
         codename: string;
         external_id?: string;
         guidelines?: string;
+        validation_regex?: {
+            is_active: boolean,
+            regex: string,
+            flags?: string,
+            validation_message?: string
+        };
     }
 
     export interface IElementWithId {

--- a/lib/models/elements/content-type-element.models.ts
+++ b/lib/models/elements/content-type-element.models.ts
@@ -200,6 +200,7 @@ export namespace ContentTypeElements {
             applies_to: 'words' | 'characters';
         };
         validation_regex?: {
+            is_active: boolean,
             regex: string,
             flags?: string,
             validation_message?: string

--- a/test/browser/fake-responses/content-types/fake-add-content-type.json
+++ b/test/browser/fake-responses/content-types/fake-add-content-type.json
@@ -12,6 +12,7 @@
       "id": "116a2441-6441-7124-c85b-46a4fef5dcb9",
       "codename": "video_id",
       "validation_regex": {
+        "is_active": true,
         "regex": "^[a-z]$",
         "flags": null,
         "validation_message": "Type a value matching the pattern required in this element."


### PR DESCRIPTION
### Motivation

Fixes #70

Also adds is_active property to validation_message in text element

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
